### PR TITLE
chore(deps): Bump com.diffplug.gradle.spotless from 3.27.0 to 3… (#2032)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.diffplug.gradle.spotless" version "3.27.0"
+    id "com.diffplug.gradle.spotless" version "3.27.1"
 }
 apply plugin: 'com.android.application'
 apply plugin: 'io.sentry.android.gradle'


### PR DESCRIPTION
Bumps com.diffplug.gradle.spotless from 3.27.0 to 3.27.1.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

Fixes #[Add issue number here. If you do not solve the issue entirely, please change the message e.g. "First steps for issues #IssueNumber]

Checklist:

- [ ] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [ ] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [ ] My branch is up-to-date with the Upstream development branch.

Changes: [Add here what changes were made in this issue and if possible provide links.]

Screenshots for the change:
